### PR TITLE
modified extract_parts function to return extra dictinory of part , coords

### DIFF
--- a/processing.py
+++ b/processing.py
@@ -6,6 +6,14 @@ import cv2
 
 import util
 
+COCO_BODY_PARTS = ['nose', 'neck',
+                   'right_shoulder', ' right_elbow', 'right_wrist',
+                   'left_shoulder', 'left_elbow', 'left_wrist',
+                   'right_hip', 'right_knee', 'right_ankle',
+                   'left_hip', 'left_knee', 'left_ankle',
+                   'right_eye', 'left_eye', 'right_ear', 'left_ear', 'background'
+                   ]
+
 
 def extract_parts(input_image, params, model, model_params):
     multiplier = [x * model_params['boxsize'] / input_image.shape[0] for x in params['scale_search']]
@@ -178,8 +186,14 @@ def extract_parts(input_image, params, model, model_params):
         if subset[i][-1] < 4 or subset[i][-2] / subset[i][-1] < 0.4:
             delete_idx.append(i)
     subset = np.delete(subset, delete_idx, axis=0)
-
-    return all_peaks, subset, candidate
+    points = []
+    for peak in all_peaks:
+        try:
+            points.append((peak[0][:2]))
+        except IndexError:
+            points.append((None, None))
+    body_parts = dict(zip(COCO_BODY_PARTS, points))
+    return body_parts, all_peaks, subset, candidate
 
 
 def draw(input_image, all_peaks, subset, candidate, resize_fac=1):


### PR DESCRIPTION
in many application generating a mapping between body parts and their coords is very useful , so in this pull request i propose that **extract_parts** function in file **processing.py** may return extra dictionary body_parts it is a mapping between parts and their x,y coords
for example :
`{'nose': (547, 338), 'neck': (577, 482), 'right_shoulder': (486, 469), ' right_elbow': (339, 275), 'right_wrist': (222, 132), 'left_shoulder': (672, 491), 'left_elbow': (845, 299), 'left_wrist': (1020, 134), 'right_hip': (411, 835), 'right_knee': (None, None), 'right_ankle': (None, None), 'left_hip': (565, 862), 'left_knee': (None, None), 'left_ankle': (None, None), 'right_eye': (522, 313), 'left_eye': (574, 310), 'right_ear': (499, 335), 'left_ear': (627, 328)}`